### PR TITLE
Ensure loading the correct gtk version

### DIFF
--- a/branches/0.3/pywinery/__init__.py
+++ b/branches/0.3/pywinery/__init__.py
@@ -37,6 +37,8 @@ import datetime
 import math
 import shutil
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib, Gio, GdkPixbuf, GObject
 
 py3k = sys.version > '3'


### PR DESCRIPTION
Fixes the error/warning
`Gtk was imported without specifying a version first.`